### PR TITLE
Less strict version for thelia/installer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "LGPL V3",
     "description": "For creating customer families",
     "require": {
-        "thelia/installer": "1.0"
+        "thelia/installer": "~1.0"
     },
     "extra": {
         "installer-name": "CustomerFamily"


### PR DESCRIPTION
The module currently require thelia/installer in a very strict 1.0 version. This prevent it from being installed alongside other modules that may require for example a ~1.1 version.   